### PR TITLE
Add CI workflow for running lint, tests, and coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,65 @@
+name: build
+
+on: [push, pull_request]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+    test:
+        strategy:
+            matrix:
+                py:
+                    - "3.6"
+                    - "3.9"
+                    - "pypy3.9"
+                os:
+                    - "macos-latest"
+                architecture:
+                    - x64
+        name: "Python: ${{ matrix.py }}-${{ matrix.architecture }} on ${{ matrix.os }}"
+        runs-on: ${{ matrix.os }}
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: ${{ matrix.py }}
+                  architecture: ${{ matrix.architecture }}
+            - name: Install dependencies
+              run: make build-for-test
+            - name: Run tests
+              run: make test-matrix
+    coverage:
+        runs-on: macos-latest
+        name: Report coverage
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.8
+                  architecture: x64
+            - name: Install dependencies
+              run: make build-for-test
+            - name: Report coverage
+              run: make cover-coveralls
+    lint:
+        runs-on: macos-latest
+        name: Lint the package
+        steps:
+            - uses: actions/checkout@v3
+            - name: Setup python
+              uses: actions/setup-python@v4
+              with:
+                  python-version: 3.8
+                  architecture: x64
+            - name: Install dependencies
+              run: make build
+            - name: Lint
+              run: make lint

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![build](https://github.com/drym-org/old-abe/actions/workflows/test.yml/badge.svg)](https://github.com/drym-org/old-abe/actions/workflows/test.yml)
+[![Coverage Status](https://coveralls.io/repos/github/drym-org/old-abe/badge.svg?branch=main)](https://coveralls.io/github/drym-org/old-abe?branch=main)
+
 ![abe-silhouette](https://user-images.githubusercontent.com/401668/205166513-1cf81032-812f-46b3-9612-a6dc8c79f589.png)
 
 "Old Abe" – accountant for all of your ABE needs.


### PR DESCRIPTION
(From the [countvajhula/composer](https://github.com/countvajhula/composer) repo)

### Summary of Changes

Adds a workflow file to run lint, tests, and coverage on every commit.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
