### PR TITLE
Misc tests for money_in

### DIFF
--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -149,7 +149,12 @@ def calculate_incoming_investment(email, incoming_amount, price):
 
 
 def calculate_incoming_attribution(email, incoming_investment, valuation):
+    '''
+    If there is an incoming investment, find out what proportion it
+    represents of the overall valuation of the project.
+    '''
     if incoming_investment > 0:
+        # TODO - do we need to wrap anything in a Decimal here?
         share = incoming_investment / valuation
         return email, share
     else:

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -20,6 +20,11 @@ ATTRIBUTIONS_FILE = os.path.join(ABE_ROOT, 'attributions.txt')
 
 
 def parse_percentage(value):
+    '''
+    Translates values expressed in percentage format (75.234%) into
+    their decimal equivalents (0.75234). This effectively divides
+    the value by 100 without losing precision.
+    '''
     value = re.sub("[^0-9.]", "", value)
     value = "00" + value
     if "." not in value:
@@ -32,6 +37,11 @@ def parse_percentage(value):
 
 
 def serialize_proportion(value):
+    '''
+    Translates values expressed in decimal format (0.75234) into
+    their percentage equivalents (75.234%). This effectively multiplies
+    the value by 100 without losing precision.
+    '''
     value = str(value)
     if "." in value:
         value = value + "0"
@@ -51,7 +61,6 @@ def read_payment(payment_file, payments_dir):
     with open(os.path.join(payments_dir, payment_file)) as f:
         for row in csv.reader(f, skipinitialspace=True):
             name, email, amount = row
-            amount = parse_percentage(amount)
             return email, amount
 
 
@@ -77,7 +86,7 @@ def read_attributions():
         for row in csv.reader(f):
             email, percentage = row
             percentage = Decimal(re.sub("[^0-9.]", "", percentage))
-            attributions[email] = percentage / Decimal("100")
+            attributions[email] = parse_percentage(percentage)
     assert sum(attributions.values()) == Decimal("1")
     return attributions
 

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -21,7 +21,7 @@ ATTRIBUTIONS_FILE = os.path.join(ABE_ROOT, 'attributions.txt')
 
 def parse_percentage(value):
     '''
-    Translates values expressed in percentage format (75.234%) into
+    Translates values expressed in percentage format (75.234) into
     their decimal equivalents (0.75234). This effectively divides
     the value by 100 without losing precision.
     '''
@@ -39,7 +39,7 @@ def parse_percentage(value):
 def serialize_proportion(value):
     '''
     Translates values expressed in decimal format (0.75234) into
-    their percentage equivalents (75.234%). This effectively multiplies
+    their percentage equivalents (75.234). This effectively multiplies
     the value by 100 without losing precision.
     '''
     value = str(value)

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -42,7 +42,8 @@ def serialize_proportion(value):
     their percentage equivalents (75.234). This effectively multiplies
     the value by 100 without losing precision.
     '''
-    value = str(value)
+    # otherwise, decimal gets translated '2E-7.0'
+    value = format(value, "f")
     if "." in value:
         value = value + "0"
     else:

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -62,7 +62,8 @@ def read_payment(payment_file, payments_dir):
     with open(os.path.join(payments_dir, payment_file)) as f:
         for row in csv.reader(f, skipinitialspace=True):
             name, email, amount = row
-            return email, amount
+            amount = re.sub("[^0-9.]", "", amount)
+            return email, Decimal(amount)
 
 
 def read_price():
@@ -86,7 +87,6 @@ def read_attributions():
     with open(ATTRIBUTIONS_FILE) as f:
         for row in csv.reader(f):
             email, percentage = row
-            percentage = Decimal(re.sub("[^0-9.]", "", percentage))
             attributions[email] = parse_percentage(percentage)
     assert sum(attributions.values()) == Decimal("1")
     return attributions

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -50,9 +50,9 @@ class TestSerializeProportion:
     def test_almost_1(self):
         assert serialize_proportion(Decimal('0.9523452')) == '95.2345200'
 
-    # todo - test not passing, decimal is getting translated to '2E-7.0'
-    def test_very_small_number(self):
-        assert serialize_proportion(Decimal('0.0000002')) == '0.00002'
+    # todo - test not passing, decimal is getting translated '2E-7.0'
+    # def test_very_small_number(self):
+    #     assert serialize_proportion(Decimal('0.0000002')) == '0.00002'
 
     def test_decimal_places_at_precision_context(self):
         assert serialize_proportion(Decimal('0.1234567891')) == '12.3456789100'

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -3,6 +3,7 @@ from oldabe.money_in import (
     calculate_incoming_investment,
     parse_percentage,
     serialize_proportion,
+    calculate_incoming_attribution,
     correct_rounding_error,
     get_rounding_difference,
     ROUNDING_TOLERANCE,
@@ -55,6 +56,20 @@ class TestSerializeProportion:
 
     def test_decimal_places_at_precision_context(self):
         assert serialize_proportion(Decimal('0.1234567891')) == '12.3456789100'
+
+
+class TestCalculateIncomingAttribution:
+    def test_incoming_investment_less_than_zero(self):
+        assert calculate_incoming_attribution('a@b.co', -50, 10000) == None
+
+    def test_incoming_investment_is_zero(self):
+        assert calculate_incoming_attribution('a@b.co', 0, 10000) == None
+
+    def test_normal_incoming_investment(self):
+        assert calculate_incoming_attribution('a@b.co', 50, 10000) == ('a@b.co', 0.005)
+
+    def test_large_incoming_investment(self):
+        assert calculate_incoming_attribution('a@b.co', 5000, 10000) == ('a@b.co', 0.5)
 
 
 class TestGetRoundingDifference:

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from oldabe.money_in import (
     calculate_incoming_investment,
     parse_percentage,
+    serialize_proportion,
     correct_rounding_error,
     get_rounding_difference,
     ROUNDING_TOLERANCE,
@@ -15,7 +16,6 @@ from .fixtures import (
     excess_attributions,
     shortfall_attributions,
 )  # noqa
-
 
 
 class TestParsePercentage:
@@ -40,6 +40,21 @@ class TestParsePercentage:
     def test_100(self):
         assert parse_percentage('100') == Decimal('1')
 
+
+class TestSerializeProportion:
+    def test_0(self):
+        assert serialize_proportion(Decimal('0')) == '0.0'
+
+    # todo - I think we decided we're ok with these trailing zeros?
+    def test_almost_1(self):
+        assert serialize_proportion(Decimal('0.9523452')) == '95.2345200'
+
+    # todo - test not passing, decimal is getting translated to '2E-7.0'
+    def test_very_small_number(self):
+        assert serialize_proportion(Decimal('0.0000002')) == '0.00002'
+
+    def test_decimal_places_at_precision_context(self):
+        assert serialize_proportion(Decimal('0.1234567891')) == '12.3456789100'
 
 
 class TestGetRoundingDifference:

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from oldabe.money_in import (
     calculate_incoming_investment,
+    parse_percentage,
     correct_rounding_error,
     get_rounding_difference,
     ROUNDING_TOLERANCE,
@@ -14,6 +15,31 @@ from .fixtures import (
     excess_attributions,
     shortfall_attributions,
 )  # noqa
+
+
+
+class TestParsePercentage:
+    def test_an_integer(self):
+        assert parse_percentage('75') == Decimal('0.75')
+
+    def test_non_integer_greater_than_1(self):
+        assert parse_percentage('75.334455') == Decimal('0.75334455')
+
+    def test_non_integer_less_than_1(self):
+        assert parse_percentage('0.334455') == Decimal('0.00334455')
+
+    def test_decimal_places_at_precision_context(self):
+        assert parse_percentage('5.1234567891') == Decimal('0.051234567891')
+
+    def test_very_small_number(self):
+        assert parse_percentage('0.000001') == Decimal('0.00000001')
+
+    def test_0(self):
+        assert parse_percentage('0') == Decimal('0')
+
+    def test_100(self):
+        assert parse_percentage('100') == Decimal('1')
+
 
 
 class TestGetRoundingDifference:

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -66,10 +66,16 @@ class TestCalculateIncomingAttribution:
         assert calculate_incoming_attribution('a@b.co', 0, 10000) == None
 
     def test_normal_incoming_investment(self):
-        assert calculate_incoming_attribution('a@b.co', 50, 10000) == ('a@b.co', 0.005)
+        assert calculate_incoming_attribution('a@b.co', 50, 10000) == (
+            'a@b.co',
+            0.005,
+        )
 
     def test_large_incoming_investment(self):
-        assert calculate_incoming_attribution('a@b.co', 5000, 10000) == ('a@b.co', 0.5)
+        assert calculate_incoming_attribution('a@b.co', 5000, 10000) == (
+            'a@b.co',
+            0.5,
+        )
 
 
 class TestGetRoundingDifference:

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -50,9 +50,8 @@ class TestSerializeProportion:
     def test_almost_1(self):
         assert serialize_proportion(Decimal('0.9523452')) == '95.2345200'
 
-    # todo - test not passing, decimal is getting translated '2E-7.0'
-    # def test_very_small_number(self):
-    #     assert serialize_proportion(Decimal('0.0000002')) == '0.00002'
+    def test_very_small_number(self):
+        assert serialize_proportion(Decimal('0.0000002')) == '0.0000200'
 
     def test_decimal_places_at_precision_context(self):
         assert serialize_proportion(Decimal('0.1234567891')) == '12.3456789100'


### PR DESCRIPTION
### Summary of Changes
Added tests and doc strings for `parse_percentage`, `serialize_proportion`, and `calculate_incoming_attribution`.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
