### PR TITLE
Make operation more "transactional" and fix valuation inflation

### DIFF
--- a/oldabe/models.py
+++ b/oldabe/models.py
@@ -30,3 +30,9 @@ class Payment:
     amount: Decimal = 0
     attributable: bool = True
     file: str = None
+
+
+@dataclass
+class Attribution:
+    email: str = None
+    share: Decimal = 0

--- a/oldabe/models.py
+++ b/oldabe/models.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 @dataclass
 class Transaction:
     email: str = None
-    amount: Decimal = None
+    amount: Decimal = 0
     payment_file: str = None
     commit_hash: str = None
     created_at: datetime = field(default_factory=datetime.utcnow)
@@ -27,6 +27,6 @@ class Debt:
 @dataclass
 class Payment:
     email: str = None
-    amount: Decimal = None
+    amount: Decimal = 0
     attributable: bool = True
     file: str = None

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -257,7 +257,6 @@ def dilute_attributions(incoming_attribution, attributions):
     """
     renormalize(attributions, incoming_attribution)
     correct_rounding_error(attributions, incoming_attribution[0])
-    write_attributions(attributions)
 
 
 def inflate_valuation(valuation, amount):
@@ -265,9 +264,7 @@ def inflate_valuation(valuation, amount):
     Determine the posterior valuation as the fresh investment amount
     added to the prior valuation.
     """
-    new_valuation = valuation + amount
-    write_valuation(new_valuation)
-    return new_valuation
+    return valuation + amount
 
 
 def get_git_revision_short_hash() -> str:
@@ -315,6 +312,7 @@ def handle_investment(payment, attributions, price, prior_valuation):
     )
     if incoming_attribution:
         dilute_attributions(incoming_attribution, attributions)
+    return posterior_valuation
 
 
 def _get_unprocessed_payment_files(attributable=True):
@@ -340,7 +338,8 @@ def process_new_attributable_payments(attributions):
         print(payment_file)
         payment = read_payment(payment_file, attributable=True)
         distribute_payment(payment, attributions)
-        handle_investment(payment, attributions, price, valuation)
+        valuation = handle_investment(payment, attributions, price, valuation)
+    return valuation
 
 
 def process_new_nonattributable_payments(attributions):
@@ -366,7 +365,10 @@ def process_new_payments():
     attributions = read_attributions()
     # this does not change attributions
     process_new_nonattributable_payments(attributions)
-    process_new_attributable_payments(attributions)
+    # this may mutate attributions
+    posterior_valuation = process_new_attributable_payments(attributions)
+    write_attributions(attributions)
+    write_valuation(posterior_valuation)
 
 
 def main():

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -237,7 +237,7 @@ def write_attributions(attributions):
             writer.writerow(row)
 
 
-def write_transactions(transactions):
+def write_append_transactions(transactions):
     with open(TRANSACTIONS_FILE, 'a') as f:
         writer = csv.writer(f)
         for row in transactions:
@@ -294,7 +294,7 @@ def distribute_payment(payment, attributions):
     transactions = generate_transactions(
         payment.amount, attributions, payment.file, commit_hash
     )
-    write_transactions(transactions)
+    write_append_transactions(transactions)
 
 
 def handle_investment(payment, attributions, price, prior_valuation):

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -167,9 +167,9 @@ def calculate_incoming_investment(payment, price):
     return max(0, incoming_investment)
 
 
-def calculate_incoming_attribution(email,
-                                   incoming_investment,
-                                   posterior_valuation):
+def calculate_incoming_attribution(
+    email, incoming_investment, posterior_valuation
+):
     """
     If there is an incoming investment, find out what proportion it
     represents of the overall (posterior) valuation of the project.
@@ -208,7 +208,8 @@ def renormalize(attributions, incoming_attribution):
         attributions[email] *= target_proportion
     # add incoming share to existing investor or record new investor
     attributions[incoming_attribution.email] = (
-        attributions.get(incoming_attribution.email, 0) + incoming_attribution.share
+        attributions.get(incoming_attribution.email, 0)
+        + incoming_attribution.share
     )
 
 
@@ -301,11 +302,11 @@ def handle_investment(payment, attributions, price, prior_valuation):
     attributed a share commensurate with their investment, diluting the
     attributions.
     """
-    incoming_investment = calculate_incoming_investment(
-        payment, price
-    )
+    incoming_investment = calculate_incoming_investment(payment, price)
     # inflate valuation by the amount of the fresh investment
-    posterior_valuation = inflate_valuation(prior_valuation, incoming_investment)
+    posterior_valuation = inflate_valuation(
+        prior_valuation, incoming_investment
+    )
     incoming_attribution = calculate_incoming_attribution(
         payment.email, incoming_investment, posterior_valuation
     )
@@ -366,7 +367,9 @@ def process_new_payments():
     # this does not change attributions or valuation
     process_new_nonattributable_payments(attributions)
     # this may mutate attributions and inflate valuation
-    transactions, posterior_valuation = process_new_attributable_payments(attributions)
+    transactions, posterior_valuation = process_new_attributable_payments(
+        attributions
+    )
     # we only write the changes to disk at the end
     # so that if any errors are encountered, no
     # changes are made.

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -18,6 +18,8 @@ PRICE_FILE = os.path.join(ABE_ROOT, 'price.txt')
 VALUATION_FILE = os.path.join(ABE_ROOT, 'valuation.txt')
 ATTRIBUTIONS_FILE = os.path.join(ABE_ROOT, 'attributions.txt')
 
+ROUNDING_TOLERANCE = Decimal("0.000001")
+
 
 def parse_percentage(value):
     """
@@ -165,27 +167,25 @@ def calculate_incoming_investment(payment, price):
     return max(0, incoming_investment)
 
 
-def calculate_incoming_attribution(email, incoming_investment, valuation):
+def calculate_incoming_attribution(email,
+                                   incoming_investment,
+                                   posterior_valuation):
     """
     If there is an incoming investment, find out what proportion it
-    represents of the overall valuation of the project.
+    represents of the overall (posterior) valuation of the project.
     """
     if incoming_investment > 0:
-        # TODO - do we need to wrap anything in a Decimal here?
-        share = incoming_investment / valuation
+        share = incoming_investment / posterior_valuation
         return email, share
     else:
         return None
 
 
-ROUNDING_TOLERANCE = Decimal("0.000001")
-
-
 def get_rounding_difference(attributions):
-    """Due to finite precision, the Decimal module will round up or down
-    on the last decimal place. This could result in the aggregate value not
-    quite totaling to 1. This corrects that total by either adding or
-    subtracting the difference from the incoming attribution.
+    """
+    Get the difference of the total of the attributions from 1, which is
+    expected to occur due to finite precision. If the difference exceeds the
+    expected error tolerance, an error is signaled.
     """
     total = sum(attributions.values())
     difference = total - Decimal("1")
@@ -194,6 +194,14 @@ def get_rounding_difference(attributions):
 
 
 def renormalize(attributions, incoming_attribution):
+    """
+    The incoming attribution is determined as a proportion of the total
+    posterior valuation.  As the existing attributions total to 1 and don't
+    account for it, they must be proportionately scaled so that their new total
+    added to the incoming attribution once again totals to one, i.e. is
+    "renormalized."  This effectively dilutes the attributions by the magnitude
+    of the incoming attribution.
+    """
     incoming_email, incoming_share = incoming_attribution
     target_proportion = Decimal("1") - incoming_share
     for email in attributions:
@@ -203,6 +211,16 @@ def renormalize(attributions, incoming_attribution):
     attributions[incoming_email] = (
         attributions.get(incoming_email, 0) + incoming_share
     )
+
+
+def correct_rounding_error(attributions, incoming_email):
+    """Due to finite precision, the Decimal module will round up or down
+    on the last decimal place. This could result in the aggregate value not
+    quite totaling to 1. This corrects that total by either adding or
+    subtracting the difference from the incoming attribution (by convention).
+    """
+    difference = get_rounding_difference(attributions)
+    attributions[incoming_email] -= difference
 
 
 def write_attributions(attributions):
@@ -222,29 +240,36 @@ def write_attributions(attributions):
             writer.writerow(row)
 
 
-def correct_rounding_error(attributions, incoming_email):
-    difference = get_rounding_difference(attributions)
-    attributions[incoming_email] -= difference
-
-
-def update_attributions(incoming_attribution, attributions):
-    renormalize(attributions, incoming_attribution)
-    correct_rounding_error(attributions, incoming_attribution[0])
-    write_attributions(attributions)
-
-
-def update_transactions(transactions):
+def write_transactions(transactions):
     with open(TRANSACTIONS_FILE, 'a') as f:
         writer = csv.writer(f)
         for row in transactions:
             writer.writerow(astuple(row))
 
 
-def update_valuation(valuation, amount):
-    new_valuation = valuation + amount
+def write_valuation(valuation):
     with open(VALUATION_FILE, 'w') as f:
         writer = csv.writer(f)
-        writer.writerow((new_valuation,))
+        writer.writerow((valuation,))
+
+
+def dilute_attributions(incoming_attribution, attributions):
+    """
+    Incorporate a fresh attributive share by diluting existing attributions,
+    and correcting any rounding error that may arise from this.
+    """
+    renormalize(attributions, incoming_attribution)
+    correct_rounding_error(attributions, incoming_attribution[0])
+    write_attributions(attributions)
+
+
+def inflate_valuation(valuation, amount):
+    """
+    Determine the posterior valuation as the fresh investment amount
+    added to the prior valuation.
+    """
+    new_valuation = valuation + amount
+    write_valuation(new_valuation)
     return new_valuation
 
 
@@ -257,7 +282,7 @@ def get_git_revision_short_hash() -> str:
     )
 
 
-def process_payment(payment, attributions):
+def distribute_payment(payment, attributions):
     """
     Generate transactions to contributors from a (new) payment.
 
@@ -272,10 +297,10 @@ def process_payment(payment, attributions):
     transactions = generate_transactions(
         payment.amount, attributions, payment.file, commit_hash
     )
-    update_transactions(transactions)
+    write_transactions(transactions)
 
 
-def handle_investment(payment, attributions, price, valuation):
+def handle_investment(payment, attributions, price, prior_valuation):
     """
     For "attributable" payments (the default), we determine
     if some portion of it counts as an investment in the project. If it does,
@@ -283,15 +308,16 @@ def handle_investment(payment, attributions, price, valuation):
     attributed a share commensurate with their investment, diluting the
     attributions.
     """
-    incoming_investment = calculate_incoming_investment(payment, price)
+    incoming_investment = calculate_incoming_investment(
+        payment, price
+    )
     # inflate valuation by the amount of the fresh investment
-    valuation = update_valuation(valuation, incoming_investment)
+    posterior_valuation = inflate_valuation(prior_valuation, incoming_investment)
     incoming_attribution = calculate_incoming_attribution(
-        payment.email, incoming_investment, valuation
+        payment.email, incoming_investment, posterior_valuation
     )
     if incoming_attribution:
-        # dilute attributions
-        update_attributions(incoming_attribution, attributions)
+        dilute_attributions(incoming_attribution, attributions)
 
 
 def _get_unprocessed_payment_files(attributable=True):
@@ -316,7 +342,7 @@ def process_new_attributable_payments(attributions):
     for payment_file in unprocessed_payments:
         print(payment_file)
         payment = read_payment(payment_file, attributable=True)
-        process_payment(payment, attributions)
+        distribute_payment(payment, attributions)
         handle_investment(payment, attributions, price, valuation)
 
 
@@ -336,13 +362,14 @@ def process_new_nonattributable_payments(attributions):
     for payment_file in unprocessed_payments:
         print(payment_file)
         payment = read_payment(payment_file, attributable=False)
-        process_payment(payment, attributions)
+        distribute_payment(payment, attributions)
 
 
 def process_new_payments():
     attributions = read_attributions()
-    process_new_attributable_payments(attributions)
+    # this does not change attributions
     process_new_nonattributable_payments(attributions)
+    process_new_attributable_payments(attributions)
 
 
 def main():

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -227,9 +227,6 @@ def write_attributions(attributions):
     # don't write attributions if they aren't normalized
     assert sum(attributions.values()) == Decimal("1")
     # format for output as percentages
-    # BUG: this step causes the result to lose precision
-    # and not total to 100 exactly, since some trailing
-    # decimal positions are lost after multiplying by 100.
     attributions = [
         (email, serialize_proportion(share))
         for email, share in attributions.items()

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -109,7 +109,9 @@ class TestGenerateTransactions:
         for t in result:
             assert t.amount == normalized_attributions[t.email] * amount
 
-    def test_everyone_in_attributions_are_represented(self, normalized_attributions):
+    def test_everyone_in_attributions_are_represented(
+        self, normalized_attributions
+    ):
         amount = 100
         payment_file = 'payment-1.txt'
         commit_hash = 'abc123'
@@ -142,25 +144,30 @@ class TestGenerateTransactions:
 
 
 class TestProcessNewAttributablePayments:
-
     @patch('oldabe.money_in._get_unprocessed_payment_files')
     @patch('oldabe.money_in.read_valuation')
     @patch('oldabe.money_in.read_price')
     @patch('oldabe.money_in.read_payment')
-    def test_collects_transactions_for_all_payments(self,
-                                                    mock_read_payment,
-                                                    mock_read_price,
-                                                    mock_read_valuation,
-                                                    mock_unprocessed_files,
-                                                    normalized_attributions):
+    def test_collects_transactions_for_all_payments(
+        self,
+        mock_read_payment,
+        mock_read_price,
+        mock_read_valuation,
+        mock_unprocessed_files,
+        normalized_attributions,
+    ):
         price = 100
         valuation = 1000
         payments = [Payment('a@b.com', 100), Payment('a@b.com', 200)]
         mock_read_payment.side_effect = call_sequence(payments)
         mock_read_price.return_value = price
         mock_read_valuation.return_value = valuation
-        mock_unprocessed_files.return_value = payments  # just any list of the right size
-        transactions, _ = process_new_attributable_payments(normalized_attributions)
+        mock_unprocessed_files.return_value = (
+            payments  # just any list of the right size
+        )
+        transactions, _ = process_new_attributable_payments(
+            normalized_attributions
+        )
         # generates N transactions for each payment,
         # and there are two payments
         assert len(transactions) == 2 * len(normalized_attributions)
@@ -174,13 +181,17 @@ class TestCalculateIncomingAttribution:
         assert calculate_incoming_attribution('a@b.co', 0, 10000) == None
 
     def test_normal_incoming_investment(self):
-        assert calculate_incoming_attribution('a@b.co', 50, 10000) == Attribution(
+        assert calculate_incoming_attribution(
+            'a@b.co', 50, 10000
+        ) == Attribution(
             'a@b.co',
             0.005,
         )
 
     def test_large_incoming_investment(self):
-        assert calculate_incoming_attribution('a@b.co', 5000, 10000) == Attribution(
+        assert calculate_incoming_attribution(
+            'a@b.co', 5000, 10000
+        ) == Attribution(
             'a@b.co',
             0.5,
         )
@@ -327,11 +338,16 @@ class TestCorrectRoundingError:
         attributions = request.getfixturevalue(attributions)
         mock_rounding_difference.return_value = test_diff
         incoming_email = 'a@b.com'
-        incoming_attribution = Attribution(incoming_email, attributions[incoming_email])
+        incoming_attribution = Attribution(
+            incoming_email, attributions[incoming_email]
+        )
         other_attributions = attributions.copy()
         other_attributions.pop(incoming_attribution.email)
         correct_rounding_error(attributions, incoming_attribution)
-        assert attributions[incoming_attribution.email] == incoming_attribution.share - test_diff
+        assert (
+            attributions[incoming_attribution.email]
+            == incoming_attribution.share - test_diff
+        )
 
     @pytest.mark.parametrize(
         "attributions, test_diff",
@@ -354,7 +370,9 @@ class TestCorrectRoundingError:
         attributions = request.getfixturevalue(attributions)
         mock_rounding_difference.return_value = test_diff
         incoming_email = 'a@b.com'
-        incoming_attribution = Attribution(incoming_email, attributions[incoming_email])
+        incoming_attribution = Attribution(
+            incoming_email, attributions[incoming_email]
+        )
         other_attributions = attributions.copy()
         other_attributions.pop(incoming_attribution.email)
         correct_rounding_error(attributions, incoming_attribution)

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -11,7 +11,7 @@ from oldabe.money_in import (
     renormalize,
     inflate_valuation,
 )
-from oldabe.models import Payment
+from oldabe.models import Attribution, Payment
 import pytest
 from unittest.mock import patch
 from .fixtures import (
@@ -136,13 +136,13 @@ class TestCalculateIncomingAttribution:
         assert calculate_incoming_attribution('a@b.co', 0, 10000) == None
 
     def test_normal_incoming_investment(self):
-        assert calculate_incoming_attribution('a@b.co', 50, 10000) == (
+        assert calculate_incoming_attribution('a@b.co', 50, 10000) == Attribution(
             'a@b.co',
             0.005,
         )
 
     def test_large_incoming_investment(self):
-        assert calculate_incoming_attribution('a@b.co', 5000, 10000) == (
+        assert calculate_incoming_attribution('a@b.co', 5000, 10000) == Attribution(
             'a@b.co',
             0.5,
         )
@@ -204,7 +204,7 @@ class TestRenormalize:
             'c@d.com': Decimal('0.05'),
         }
 
-        incoming_attribution = ['c@d.com', Decimal('0.05')]
+        incoming_attribution = Attribution('c@d.com', Decimal('0.05'))
         renormalize(attributions, incoming_attribution)
         assert attributions == renormalized_attributions
 
@@ -216,7 +216,7 @@ class TestRenormalize:
             'c@d.com': Decimal('0.5'),
         }
 
-        incoming_attribution = ['c@d.com', Decimal('0.5')]
+        incoming_attribution = Attribution('c@d.com', Decimal('0.5'))
         renormalize(attributions, incoming_attribution)
         assert attributions == renormalized_attributions
 
@@ -228,7 +228,7 @@ class TestRenormalize:
             'c@d.com': Decimal('0.7'),
         }
 
-        incoming_attribution = ['c@d.com', Decimal('0.7')]
+        incoming_attribution = Attribution('c@d.com', Decimal('0.7'))
         renormalize(attributions, incoming_attribution)
         assert attributions == renormalized_attributions
 
@@ -239,7 +239,7 @@ class TestRenormalize:
             'b@c.com': Decimal('0.81'),
         }
 
-        incoming_attribution = ['b@c.com', Decimal('0.05')]
+        incoming_attribution = Attribution('b@c.com', Decimal('0.05'))
         renormalize(attributions, incoming_attribution)
         assert attributions == renormalized_attributions
 
@@ -250,7 +250,7 @@ class TestRenormalize:
             'b@c.com': Decimal('0.9'),
         }
 
-        incoming_attribution = ['b@c.com', Decimal('0.5')]
+        incoming_attribution = Attribution('b@c.com', Decimal('0.5'))
         renormalize(attributions, incoming_attribution)
         assert attributions == renormalized_attributions
 
@@ -261,7 +261,7 @@ class TestRenormalize:
             'b@c.com': Decimal('0.94'),
         }
 
-        incoming_attribution = ['b@c.com', Decimal('0.7')]
+        incoming_attribution = Attribution('b@c.com', Decimal('0.7'))
         renormalize(attributions, incoming_attribution)
         assert attributions == renormalized_attributions
 
@@ -289,11 +289,11 @@ class TestCorrectRoundingError:
         attributions = request.getfixturevalue(attributions)
         mock_rounding_difference.return_value = test_diff
         incoming_email = 'a@b.com'
-        incoming_share = attributions[incoming_email]
+        incoming_attribution = Attribution(incoming_email, attributions[incoming_email])
         other_attributions = attributions.copy()
-        other_attributions.pop(incoming_email)
-        correct_rounding_error(attributions, incoming_email)
-        assert attributions[incoming_email] == incoming_share - test_diff
+        other_attributions.pop(incoming_attribution.email)
+        correct_rounding_error(attributions, incoming_attribution)
+        assert attributions[incoming_attribution.email] == incoming_attribution.share - test_diff
 
     @pytest.mark.parametrize(
         "attributions, test_diff",
@@ -316,10 +316,11 @@ class TestCorrectRoundingError:
         attributions = request.getfixturevalue(attributions)
         mock_rounding_difference.return_value = test_diff
         incoming_email = 'a@b.com'
+        incoming_attribution = Attribution(incoming_email, attributions[incoming_email])
         other_attributions = attributions.copy()
-        other_attributions.pop(incoming_email)
-        correct_rounding_error(attributions, incoming_email)
-        attributions.pop(incoming_email)
+        other_attributions.pop(incoming_attribution.email)
+        correct_rounding_error(attributions, incoming_attribution)
+        attributions.pop(incoming_attribution.email)
         assert attributions == other_attributions
 
 

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -9,7 +9,7 @@ from oldabe.money_in import (
     get_rounding_difference,
     ROUNDING_TOLERANCE,
     renormalize,
-    update_valuation,
+    inflate_valuation,
 )
 from oldabe.models import Payment
 import pytest
@@ -328,7 +328,7 @@ class TestUpdateValuation:
     def test_valuation_inflates_by_fresh_value(self, mock_open):
         amount = 100
         valuation = 1000
-        new_valuation = update_valuation(valuation, amount)
+        new_valuation = inflate_valuation(valuation, amount)
         assert new_valuation == amount + valuation
 
 

--- a/tests/unit/utils.py
+++ b/tests/unit/utils.py
@@ -1,0 +1,17 @@
+def call_sequence(seq):
+    """
+    A test helper to return from a provided sequence of values each time
+    the function is called.
+    """
+    ret = {}
+    for i, e in enumerate(seq):
+        ret[i] = e
+    count = 0
+
+    def mock_fn(*args, **kwargs):
+        nonlocal count
+        val = ret[count]
+        count += 1
+        return val
+
+    return mock_fn


### PR DESCRIPTION
### Summary of Changes

- inflation of valuation was only taking the immediate payment into account and wasn't accumulating the amounts - fixed
- if an error was encountered it would sometimes already have made changes and things would be left in a weird state. Now we only write to disk at the end
- some docstrings
- rename some functions

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
