### PR TITLE
Fix excess zero padding

### DIFF
--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -47,16 +47,27 @@ def serialize_proportion(value):
     # otherwise, decimal gets translated '2E-7.0'
     value = format(value, "f")
     if "." in value:
-        value = value + "0"
+        value = value + "00"
     else:
-        value = value + ".0"
+        value = value + ".00"
     value = re.sub(
         r"(?P<pre>\d)\.(?P<post>\d{2})(?P<rest>\d*)",
-        r"\g<pre>\g<post>.\g<rest>0",  # note trailing zero
+        # match a number followed by a decimal point
+        # followed by at least two digits
+        r"\g<pre>\g<post>.\g<rest>",
+        # move the decimal point two places to the right
         value,
     )
-    value = re.sub(r"^0+(\d*)", r"\1", value)
+    # strip leading insignificant zeroes
+    value = value.lstrip("0")
+    # ensure there's a single leading zero if it is
+    # a decimal value less than 1
     value = re.sub(r"^\.", r"0.", value)
+    if "." in value:
+        # strip trailing insignificant zeroes
+        value = value.rstrip("0")
+        # remove decimal point if whole number
+        value = re.sub(r"\.$", r"", value)
     return value
 
 

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -50,17 +50,28 @@ class TestParsePercentage:
 
 class TestSerializeProportion:
     def test_0(self):
-        assert serialize_proportion(Decimal('0')) == '0.0'
+        assert serialize_proportion(Decimal('0')) == '0'
 
-    # todo - I think we decided we're ok with these trailing zeros?
+    def test_0_point_0(self):
+        assert serialize_proportion(Decimal('0.0')) == '0'
+
+    def test_1(self):
+        assert serialize_proportion(Decimal('1')) == '100'
+
+    def test_1_point_0(self):
+        assert serialize_proportion(Decimal('1.0')) == '100'
+
     def test_almost_1(self):
-        assert serialize_proportion(Decimal('0.9523452')) == '95.2345200'
+        assert serialize_proportion(Decimal('0.9523452')) == '95.23452'
+
+    def test_low_precision_number(self):
+        assert serialize_proportion(Decimal('0.2')) == '20'
 
     def test_very_small_number(self):
-        assert serialize_proportion(Decimal('0.0000002')) == '0.0000200'
+        assert serialize_proportion(Decimal('0.0000002')) == '0.00002'
 
     def test_decimal_places_at_precision_context(self):
-        assert serialize_proportion(Decimal('0.1234567891')) == '12.3456789100'
+        assert serialize_proportion(Decimal('0.1234567891')) == '12.34567891'
 
 
 class TestGenerateTransactions:

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -44,8 +44,14 @@ class TestParsePercentage:
     def test_0(self):
         assert parse_percentage('0') == Decimal('0')
 
+    def test_0_point_0(self):
+        assert parse_percentage('0.0') == Decimal('0')
+
     def test_100(self):
         assert parse_percentage('100') == Decimal('1')
+
+    def test_100_point_0(self):
+        assert parse_percentage('100.0') == Decimal('1')
 
 
 class TestSerializeProportion:


### PR DESCRIPTION
### Summary of Changes

Last time, we noticed that there were extra zeros being added each time it went through a cycle of parsing and serializing between proportions and percentages. This change avoids retaining any unnecessary leading or trailing zeros.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
