### PR TITLE
Add itemized payments

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -26,7 +26,7 @@ echo "... done."
 echo "Committing updated transactions and attributions back to repo..."
 git config --global user.email "abe@drym.org"
 git config --global user.name "Old Abe"
-git add abe/transactions.txt abe/attributions.txt abe/valuation.txt
+git add abe/transactions.txt abe/attributions.txt abe/valuation.txt abe/itemized_payments.txt
 
 set +e
 

--- a/oldabe/models.py
+++ b/oldabe/models.py
@@ -32,12 +32,12 @@ class Payment:
     file: str = None
 
 
-# PaymentAllocation acts as a proxy for a Payment object that keeps track
+# ItemizedPayment acts as a proxy for a Payment object that keeps track
 # of how much of the original payment is owed to instruments and how much
 # is owed to directly to the project (attributions.txt). This allows us to
 # avoid mutating Payment records.
 @dataclass
-class PaymentAllocation
+class ItemizedPayment
     email: str = None
     fee_amount: Decimal = 0 # instruments
     project_amount: Decimal = 0 # attributions 

--- a/oldabe/models.py
+++ b/oldabe/models.py
@@ -37,12 +37,14 @@ class Payment:
 # is owed to directly to the project (attributions.txt). This allows us to
 # avoid mutating Payment records.
 @dataclass
-class ItemizedPayment
+class ItemizedPayment:
     email: str = None
-    fee_amount: Decimal = 0 # instruments
-    project_amount: Decimal = 0 # attributions 
+    fee_amount: Decimal = 0  # instruments
+    project_amount: Decimal = 0  # attributions
     attributable: bool = True
-    payment_file: str = None # acts like a foreign key to original payment object
+    payment_file: str = (
+        None  # acts like a foreign key to original payment object
+    )
 
 
 @dataclass

--- a/oldabe/models.py
+++ b/oldabe/models.py
@@ -32,6 +32,19 @@ class Payment:
     file: str = None
 
 
+# PaymentAllocation acts as a proxy for a Payment object that keeps track
+# of how much of the original payment is owed to instruments and how much
+# is owed to directly to the project (attributions.txt). This allows us to
+# avoid mutating Payment records.
+@dataclass
+class PaymentAllocation
+    email: str = None
+    fee_amount: Decimal = 0 # instruments
+    project_amount: Decimal = 0 # attributions 
+    attributable: bool = True
+    payment_file: str = None # acts like a foreign key to original payment object
+
+
 @dataclass
 class Attribution:
     email: str = None

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -203,11 +203,14 @@ def get_existing_itemized_payments():
 
 def total_amount_paid_to_project(for_email, new_itemized_payments):
     """
-    Calculates the sum of a single user's attributable payments for
-    determining how much the user has invested in the project so far.
-    Non-attributable payments do not count towards investment.
+    Calculates the sum of a single user's attributable payments (minus
+    fees paid towards instruments) for determining how much the user
+    has invested in the project so far. Non-attributable payments do
+    not count towards investment.
     """
-    all_itemized_payments = get_existing_itemized_payments() + new_itemized_payments
+    all_itemized_payments = (
+        get_existing_itemized_payments() + new_itemized_payments
+    )
     return sum(
         p.project_amount
         for p in all_itemized_payments
@@ -220,7 +223,9 @@ def calculate_incoming_investment(payment, price, new_itemized_payments):
     If the payment brings the aggregate amount paid by the payee
     above the price, then that excess is treated as investment.
     """
-    total_payments = total_amount_paid_to_project(payment.email, new_itemized_payments)
+    total_payments = total_amount_paid_to_project(
+        payment.email, new_itemized_payments
+    )
     previous_total = total_payments - payment.amount
     # how much of the incoming amount goes towards investment?
     incoming_investment = total_payments - max(price, previous_total)
@@ -370,7 +375,9 @@ def distribute_payment(payment, attributions):
     return transactions
 
 
-def handle_investment(payment, new_itemized_payments, attributions, price, prior_valuation):
+def handle_investment(
+    payment, new_itemized_payments, attributions, price, prior_valuation
+):
     """
     For "attributable" payments (the default), we determine
     if some portion of it counts as an investment in the project. If it does,
@@ -378,7 +385,9 @@ def handle_investment(payment, new_itemized_payments, attributions, price, prior
     attributed a share commensurate with their investment, diluting the
     attributions.
     """
-    incoming_investment = calculate_incoming_investment(payment, price, new_itemized_payments)
+    incoming_investment = calculate_incoming_investment(
+        payment, price, new_itemized_payments
+    )
     # inflate valuation by the amount of the fresh investment
     posterior_valuation = inflate_valuation(
         prior_valuation, incoming_investment
@@ -444,9 +453,11 @@ def process_payments_and_record_updates():
     instruments = read_attributions(INSTRUMENTS_FILE, validate=False)
     attributions = read_attributions(ATTRIBUTIONS_FILE)
 
-    transactions, posterior_valuation, new_itemized_payments = process_payments(
-        instruments, attributions
-    )
+    (
+        transactions,
+        posterior_valuation,
+        new_itemized_payments,
+    ) = process_payments(instruments, attributions)
 
     # we only write the changes to disk at the end
     # so that if any errors are encountered, no

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -6,7 +6,7 @@ from dataclasses import astuple
 import re
 import os
 import subprocess
-from .models import Attribution, Payment, Transaction
+from .models import Attribution, Payment, ItemizedPayment, Transaction
 
 ABE_ROOT = 'abe'
 PAYMENTS_DIR = os.path.join(ABE_ROOT, 'payments')
@@ -180,7 +180,7 @@ def generate_transactions(amount, attributions, payment_file, commit_hash):
 
 def get_existing_itemized_payments():
     # TODO
-    itemized_payments = set()
+    itemized_payments = []
     itemized_payments_file = os.path.join(ABE_ROOT, ITEMIZED_PAYMENTS_FILE)
     with open(itemized_payments_file) as f:
         for (
@@ -197,7 +197,7 @@ def get_existing_itemized_payments():
                 attributable,
                 payment_file,
             )
-            itemized_payments.add(itemized_payment)
+            itemized_payments.append(itemized_payment)
     return itemized_payments
 
 
@@ -428,12 +428,14 @@ def process_payments(instruments, attributions):
         # deduct the amount paid out to instruments before
         # processing it for attributions
         payment.amount -= amount_paid_out
-        new_itemized_payments += ItemizedPayment(
-            payment.email,
-            amount_paid_out,
-            payment.amount,
-            payment.attributable,
-            payment.payment_file,
+        new_itemized_payments.append(
+            ItemizedPayment(
+                payment.email,
+                amount_paid_out,
+                payment.amount,
+                payment.attributable,
+                payment.file,
+            )
         )
         if payment.amount > ACCOUNTING_ZERO:
             new_transactions += distribute_payment(payment, attributions)

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -14,6 +14,7 @@ NONATTRIBUTABLE_PAYMENTS_DIR = os.path.join(
     ABE_ROOT, 'payments', 'nonattributable'
 )
 TRANSACTIONS_FILE = 'transactions.txt'
+PAYMENT_ALLOCATIONS_FILE = 'payment_allocations.txt'
 PRICE_FILE = 'price.txt'
 VALUATION_FILE = 'valuation.txt'
 ATTRIBUTIONS_FILE = 'attributions.txt'
@@ -177,25 +178,49 @@ def generate_transactions(amount, attributions, payment_file, commit_hash):
     return transactions
 
 
-def total_amount_paid(for_email):
+def get_existing_payment_allocations():
+    # TODO
+    payment_allocations = set()
+    payment_allocations_file = os.path.join(ABE_ROOT, PAYMENT_ALLOCATIONS_FILE)
+    with open(payment_allocations_file) as f:
+        for (
+            email,
+            fee_amount,
+            project_amount,
+            attributable,
+            payment_file,
+        ) in csv.reader(f):
+            payment_allocation = PaymentAllocation(
+                email,
+                fee_amount,
+                project_amount,
+                attributable,
+                payment_file,
+            )
+            payment_allocations.add(payment_allocation)
+    return payment_allocations
+
+
+def total_amount_paid_to_project(for_email, new_payment_allocations):
     """
     Calculates the sum of a single user's attributable payments for
     determining how much the user has invested in the project so far.
     Non-attributable payments do not count towards investment.
     """
+    all_payment_allocations = get_existing_payment_allocations() + new_payment_allocations
     return sum(
-        p.amount
-        for p in get_all_payments()
+        p.project_amount
+        for p in all_payment_allocations
         if p.attributable and p.email == for_email
     )
 
 
-def calculate_incoming_investment(payment, price):
+def calculate_incoming_investment(payment, price, new_payment_allocations):
     """
     If the payment brings the aggregate amount paid by the payee
     above the price, then that excess is treated as investment.
     """
-    total_payments = total_amount_paid(payment.email)
+    total_payments = total_amount_paid_to_project(payment.email, new_payment_allocations)
     previous_total = total_payments - payment.amount
     # how much of the incoming amount goes towards investment?
     incoming_investment = total_payments - max(price, previous_total)
@@ -285,6 +310,14 @@ def write_append_transactions(transactions):
             writer.writerow(astuple(row))
 
 
+def write_append_payment_allocations(payment_allocations):
+    payment_allocations_file = os.path.join(ABE_ROOT, PAYMENT_ALLOCATIONS_FILE)
+    with open(payment_allocations_file, 'a') as f:
+        writer = csv.writer(f)
+        for row in payment_allocations:
+            writer.writerow(astuple(row))
+
+
 def write_valuation(valuation):
     rounded_valuation = f"{valuation:.2f}"
     valuation_file = os.path.join(ABE_ROOT, VALUATION_FILE)
@@ -337,7 +370,7 @@ def distribute_payment(payment, attributions):
     return transactions
 
 
-def handle_investment(payment, attributions, price, prior_valuation):
+def handle_investment(payment, new_payment_allocations, attributions, price, prior_valuation):
     """
     For "attributable" payments (the default), we determine
     if some portion of it counts as an investment in the project. If it does,
@@ -345,7 +378,7 @@ def handle_investment(payment, attributions, price, prior_valuation):
     attributed a share commensurate with their investment, diluting the
     attributions.
     """
-    incoming_investment = calculate_incoming_investment(payment, price)
+    incoming_investment = calculate_incoming_investment(payment, price, new_payment_allocations)
     # inflate valuation by the amount of the fresh investment
     posterior_valuation = inflate_valuation(
         prior_valuation, incoming_investment
@@ -377,6 +410,7 @@ def process_payments(instruments, attributions):
     price = read_price()
     valuation = read_valuation()
     new_transactions = []
+    new_payment_allocations = []
     unprocessed_payments = _get_unprocessed_payments()
     for payment in unprocessed_payments:
         transactions = distribute_payment(payment, instruments)
@@ -385,13 +419,20 @@ def process_payments(instruments, attributions):
         # deduct the amount paid out to instruments before
         # processing it for attributions
         payment.amount -= amount_paid_out
+        new_payment_allocations += PaymentAllocation(
+            payment.email,
+            amount_paid_out,
+            payment.amount,
+            payment.attributable,
+            payment.payment_file,
+        )
         if payment.amount > ACCOUNTING_ZERO:
             new_transactions += distribute_payment(payment, attributions)
         if payment.attributable:
             valuation = handle_investment(
-                payment, attributions, price, valuation
+                payment, new_payment_allocations, attributions, price, valuation
             )
-    return new_transactions, valuation
+    return new_transactions, valuation, new_payment_allocations
 
 
 def process_payments_and_record_updates():
@@ -403,7 +444,7 @@ def process_payments_and_record_updates():
     instruments = read_attributions(INSTRUMENTS_FILE, validate=False)
     attributions = read_attributions(ATTRIBUTIONS_FILE)
 
-    transactions, posterior_valuation = process_payments(
+    transactions, posterior_valuation, new_payment_allocations = process_payments(
         instruments, attributions
     )
 
@@ -413,6 +454,7 @@ def process_payments_and_record_updates():
     write_append_transactions(transactions)
     write_attributions(attributions)
     write_valuation(posterior_valuation)
+    write_append_payment_allocations(new_payment_allocations)
 
 
 def main():

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -182,22 +182,25 @@ def get_existing_itemized_payments():
     # TODO
     itemized_payments = []
     itemized_payments_file = os.path.join(ABE_ROOT, ITEMIZED_PAYMENTS_FILE)
-    with open(itemized_payments_file) as f:
-        for (
-            email,
-            fee_amount,
-            project_amount,
-            attributable,
-            payment_file,
-        ) in csv.reader(f):
-            itemized_payment = ItemizedPayment(
+    try:
+        with open(itemized_payments_file) as f:
+            for (
                 email,
                 fee_amount,
                 project_amount,
                 attributable,
                 payment_file,
-            )
-            itemized_payments.append(itemized_payment)
+            ) in csv.reader(f):
+                itemized_payment = ItemizedPayment(
+                    email,
+                    fee_amount,
+                    project_amount,
+                    attributable,
+                    payment_file,
+                )
+                itemized_payments.append(itemized_payment)
+    except FileNotFoundError:
+        itemized_payments = []
     return itemized_payments
 
 

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -412,6 +412,16 @@ def _get_unprocessed_payments():
     return unprocessed_payments
 
 
+def _create_itemized_payment(payment, fee_amount):
+    return ItemizedPayment(
+        payment.email,
+        fee_amount,
+        payment.amount,
+        payment.attributable,
+        payment.file,
+    )
+
+
 def process_payments(instruments, attributions):
     """
     Process new payments by paying out instruments and then, from the amount
@@ -433,13 +443,7 @@ def process_payments(instruments, attributions):
         # processing it for attributions
         payment.amount -= amount_paid_out
         new_itemized_payments.append(
-            ItemizedPayment(
-                payment.email,
-                amount_paid_out,
-                payment.amount,
-                payment.attributable,
-                payment.file,
-            )
+            _create_itemized_payment(payment, amount_paid_out)
         )
         # next, process attributions - using the amount owed to the project
         # (which is the amount leftover after paying instruments/fees)

--- a/oldabe/money_in.py
+++ b/oldabe/money_in.py
@@ -226,7 +226,7 @@ def calculate_incoming_investment(payment, price, new_itemized_payments):
     total_payments = total_amount_paid_to_project(
         payment.email, new_itemized_payments
     )
-    previous_total = total_payments - payment.amount
+    previous_total = total_payments - payment.amount  # fees already deducted
     # how much of the incoming amount goes towards investment?
     incoming_investment = total_payments - max(price, previous_total)
     return max(0, incoming_investment)
@@ -422,6 +422,7 @@ def process_payments(instruments, attributions):
     new_itemized_payments = []
     unprocessed_payments = _get_unprocessed_payments()
     for payment in unprocessed_payments:
+        # first, process instruments (i.e. pay fees)
         transactions = distribute_payment(payment, instruments)
         new_transactions += transactions
         amount_paid_out = sum(t.amount for t in transactions)
@@ -437,6 +438,8 @@ def process_payments(instruments, attributions):
                 payment.file,
             )
         )
+        # next, process attributions - using the amount owed to the project
+        # (which is the amount leftover after paying instruments/fees)
         if payment.amount > ACCOUNTING_ZERO:
             new_transactions += distribute_payment(payment, attributions)
         if payment.attributable:

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -61,7 +61,13 @@ def itemized_payments():
 @pytest.fixture
 def new_itemized_payments():
     return [
-        ItemizedPayment('a@b.com', Decimal('4'), Decimal('80'), True, 'payment-4.txt'),
-        ItemizedPayment('c@d.com', Decimal('5'), Decimal('20'), True, 'payment-5.txt'),
-        ItemizedPayment('c@d.com', Decimal('10'), Decimal('90'), False, 'payment-6.txt'),
+        ItemizedPayment(
+            'a@b.com', Decimal('4'), Decimal('80'), True, 'payment-4.txt'
+        ),
+        ItemizedPayment(
+            'c@d.com', Decimal('5'), Decimal('20'), True, 'payment-5.txt'
+        ),
+        ItemizedPayment(
+            'c@d.com', Decimal('10'), Decimal('90'), False, 'payment-6.txt'
+        ),
     ]

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from oldabe.models import Attribution
+from oldabe.models import ItemizedPayment
 import pytest
 
 
@@ -43,3 +43,28 @@ def empty_attributions():
 @pytest.fixture
 def single_contributor_attributions():
     return {'a@b.com': Decimal("1")}
+
+
+@pytest.fixture
+def itemized_payments():
+    data = [
+        ['a@b.com', '6', '94', 'payment-1.txt'],
+        ['a@b.com', '2', '20', 'payment-2.txt'],
+        ['c@d.com', '1', '10', 'payment-3.txt'],
+    ]
+    return [
+        ItemizedPayment(ip[0], Decimal(ip[1]), Decimal(ip[2]), True, ip[3])
+        for index, ip in enumerate(data)
+    ]
+
+
+@pytest.fixture
+def new_itemized_payments():
+    data = [
+        ['a@b.com', '4', '80', 'payment-4.txt'],
+        ['d@e.com', '10', '90', 'payment-5.txt'],
+    ]
+    return [
+        ItemizedPayment(ip[0], Decimal(ip[1]), Decimal(ip[2]), True, ip[3])
+        for index, ip in enumerate(data)
+    ]

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -60,11 +60,8 @@ def itemized_payments():
 
 @pytest.fixture
 def new_itemized_payments():
-    data = [
-        ['a@b.com', '4', '80', 'payment-4.txt'],
-        ['d@e.com', '10', '90', 'payment-5.txt'],
-    ]
     return [
-        ItemizedPayment(ip[0], Decimal(ip[1]), Decimal(ip[2]), True, ip[3])
-        for index, ip in enumerate(data)
+        ItemizedPayment('a@b.com', Decimal('4'), Decimal('80'), True, 'payment-4.txt'),
+        ItemizedPayment('c@d.com', Decimal('5'), Decimal('20'), True, 'payment-5.txt'),
+        ItemizedPayment('c@d.com', Decimal('10'), Decimal('90'), False, 'payment-6.txt'),
     ]

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -420,7 +420,7 @@ class TestInflateValuation:
 
 class TotalAmountPaidToProject:
     @patch('oldabe.money_in.get_existing_itemized_payments')
-    def test_total_amount_for_a(
+    def test_total_amount_for_a_all_attributable(
         self,
         get_existing_itemized_payments,
         itemized_payments,
@@ -429,6 +429,17 @@ class TotalAmountPaidToProject:
         get_existing_itemized_payments.return_value = itemized_payments
         total = total_amount_paid_to_project('a@b.com', new_itemized_payments)
         assert total == 194
+
+    @patch('oldabe.money_in.get_existing_itemized_payments')
+    def test_total_amount_for_c_one_non_attributable(
+        self,
+        get_existing_itemized_payments,
+        itemized_payments,
+        new_itemized_payments,
+    ):
+        get_existing_itemized_payments.return_value = itemized_payments
+        total = total_amount_paid_to_project('c@d.com', new_itemized_payments)
+        assert total == 30
 
 
 class TestCalculateIncomingInvestment:

--- a/tests/unit/money_in_test.py
+++ b/tests/unit/money_in_test.py
@@ -186,7 +186,7 @@ class TestProcessPayments:
         mock_unprocessed_files.return_value = payments
         mock_get_all_payments.return_value = payments
 
-        transactions, _ = process_payments(
+        transactions, _, _ = process_payments(
             instruments, normalized_attributions
         )
         # generates a transaction for each payment and each contributor in the
@@ -433,7 +433,7 @@ class TestCalculateIncomingInvestment:
             (Decimal("120"), Decimal("20"), Decimal("100"), Decimal("20")),
         ],
     )
-    @patch('oldabe.money_in.total_amount_paid')
+    @patch('oldabe.money_in.total_amount_paid_to_project')
     def test_matrix(
         self,
         mock_amount_paid,
@@ -446,5 +446,5 @@ class TestCalculateIncomingInvestment:
         payment = Payment(email, incoming_amount)
         # this is the total amount paid _including_ the incoming amount
         mock_amount_paid.return_value = prior_contribution + incoming_amount
-        result = calculate_incoming_investment(payment, price)
+        result = calculate_incoming_investment(payment, price, [])
         assert result == expected_investment


### PR DESCRIPTION
### Summary of Changes

Adds the concept of an ItemizedPayment for recording how much of an incoming payment went towards fees (instruments) and how much went to the project (attributions). We need this historical data when calculating the total amount that a person has paid into the project so that we can compare the total amount accurately with the price and the correct investment amount. Only the portion of a payment that went towards the project should count towards price/investment.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
