### PR TITLE
Advances tests

### DIFF
--- a/oldabe/money_in/__init__.py
+++ b/oldabe/money_in/__init__.py
@@ -85,7 +85,7 @@ def distribute_payment(
     #
 
     negative_advances = draw_down_advances(
-        available_amount, distribution, unpayable_contributors, payment
+        available_amount, distribution, unpayable_contributors, payment.file
     )
 
     #
@@ -97,7 +97,7 @@ def distribute_payment(
         negative_advances,
         distribution,
         unpayable_contributors,
-        payment,
+        payment.file,
     )
 
     #

--- a/tests/unit/advances_test.py
+++ b/tests/unit/advances_test.py
@@ -1,0 +1,80 @@
+import pytest
+from unittest.mock import patch
+import time_machine
+
+from datetime import datetime
+from decimal import Decimal
+from oldabe.distribution import Distribution
+from oldabe.models import Advance
+from oldabe.money_in.advances import draw_down_advances, advance_payments
+
+from .fixtures import normalized_attributions  # noqa
+
+# test that correct negative advances are created (or not created) for
+# a single user. check advance amount for accuracy and make sure is negative.
+
+# call: draw_down_advances(available_amount, distribution, unpayable_contributors, payment_file)
+# return: negative_advances
+
+
+class TestDrawDownAdvances:
+    def test_no_advances_exist(self, normalized_attributions):
+        distribution = Distribution(normalized_attributions)
+        negative_advances = draw_down_advances(100, distribution, [], 'payment-10.txt')
+        assert negative_advances == []
+
+    @time_machine.travel(datetime(1985, 10, 26, 1, 24), tick=False)
+    @patch('oldabe.models.default_commit_hash', return_value='abcd123')
+    @patch('oldabe.money_in.advances.Tally', return_value={'a@b.com': Decimal(100)})
+    def test_existing_advance_greater_than_payment_amount(self, mock_tally, mock_git_rev, normalized_attributions):
+        expected_advance = Advance(
+            email='a@b.com',
+            amount=Decimal('-20.0'),
+            payment_file='payment-10.txt',
+            commit_hash='abcd123',
+            created_at=datetime(1985, 10, 26, 1, 24)
+        )
+        distribution = Distribution(normalized_attributions)
+        negative_advances = draw_down_advances(100, distribution, [], 'payment-10.txt')
+        assert negative_advances == [expected_advance]
+
+    @time_machine.travel(datetime(1985, 10, 26, 1, 24), tick=False)
+    @patch('oldabe.models.default_commit_hash', return_value='abcd123')
+    @patch('oldabe.money_in.advances.Tally', return_value={'a@b.com': Decimal(10)})
+    def test_existing_advance_less_than_payment_amount(self, mock_tally, mock_git_rev, normalized_attributions):
+        expected_advance = Advance(
+            email='a@b.com',
+            amount=Decimal('-10.0'),
+            payment_file='payment-10.txt',
+            commit_hash='abcd123',
+            created_at=datetime(1985, 10, 26, 1, 24)
+        )
+        distribution = Distribution(normalized_attributions)
+        negative_advances = draw_down_advances(100, distribution, [], 'payment-10.txt')
+        assert negative_advances == [expected_advance]
+
+    @patch('oldabe.money_in.advances.Tally', return_value={'a@b.com': Decimal(10)})
+    def test_contributor_is_unpayable(self, mock_tally, normalized_attributions):
+        distribution = Distribution(normalized_attributions)
+        negative_advances = draw_down_advances(100, distribution, ['a@b.com'], 'payment-10.txt')
+        assert negative_advances == []
+
+
+# call: advance_payments(
+#     fresh_debts,
+#     negative_advances,
+#     distribution,
+#     unpayable_contributors,
+#     payment_file,
+# )
+# return: fresh_advances
+
+class TestAdvancePayments:
+    def test_empty_redistribution_pot(self):
+        pass
+
+    def test_fresh_debts_and_neg_advances_present(self):
+        pass
+
+    def test_unpayable_contributor_present(self):
+        pass

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from oldabe.models import ItemizedPayment
+from oldabe.models import ItemizedPayment, Debt, Advance
 import pytest
 
 
@@ -70,4 +70,19 @@ def new_itemized_payments():
         ItemizedPayment(
             'c@d.com', Decimal('10'), Decimal('90'), False, 'payment-6.txt'
         ),
+    ]
+
+
+@pytest.fixture
+def fresh_debts():
+    return [
+        Debt('a@b.com', Decimal('10'), Decimal('0'), 'payment-10.txt'),
+        Debt('a@b.com', Decimal('40'), Decimal('0'), 'payment-10.txt'),
+    ]
+
+@pytest.fixture
+def negative_advances():
+    return [
+        Advance('a@b.com', Decimal('-20'), 'payment-10.txt'),
+        Advance('a@b.com', Decimal('-30'), 'payment-10.txt'),
     ]


### PR DESCRIPTION
### Summary of Changes

Add tests for advances.py.
Add two fixtures for debts and advances.

### Public Domain Dedication

- [x] In contributing, I relinquish any copyright claims on my contribution and freely release it into the public domain in the simple hope that it will provide value.

(**Why**: The freely released, copyright-free work in this repository represents an investment in a better way of doing things called _attribution-based economics_. Attribution-based economics is based on the simple idea that we gain more by giving more, not by holding on to things that, truly, we could only create because we, in our turn, received from others. As it turns out, an economic system based on attribution -- where those who give more are more empowered -- is significantly more efficient than capitalism while also being stable and fair (_unlike_ capitalism, on both counts), giving it transformative power to elevate the human condition and address the problems that face us today along with a host of others that have been intractable since the beginning. You can help make this a reality by releasing your work in the same way -- freely into the public domain in the simple hope of providing value. Learn more about attribution-based economics at [drym.org](https://drym.org), tell your friends, do your part.)
